### PR TITLE
Support non-contiguous grad_output for LinearWithGradAccumulationAndAsyncCommunication

### DIFF
--- a/apex/transformer/tensor_parallel/layers.py
+++ b/apex/transformer/tensor_parallel/layers.py
@@ -349,7 +349,7 @@ class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
             handle.wait()
 
         # Convert the tensor shapes to 2D for execution compatibility
-        grad_output = grad_output.view(
+        grad_output = grad_output.reshape(
             grad_output.shape[0] * grad_output.shape[1], grad_output.shape[2]
         )
         total_input = total_input.view(total_input.shape[0] * total_input.shape[1], total_input.shape[2])


### PR DESCRIPTION
I found that I was getting this error when using `gather` on the output of a linear layer when using NeMo.
```python
  File "/mnt/nvme/home/uwu/conda/nemo-113/lib/python3.8/site-packages/ape
x/transformer/pipeline_parallel/schedules/fwd_bwd_no_pipelining.py", line
 116, in forward_backward_no_pipelining
    backward_step(
  File "/mnt/nvme/home/uwu/conda/nemo-113/lib/python3.8/site-packages/apex/transformer/pipeline_parallel/schedules/common.py", line 383, in backward_step
    torch.autograd.backward(output_tensor[0], grad_tensors=output_tensor_grad[0])
  File "/mnt/nvme/home/uwu/conda/nemo-113/lib/python3.8/site-packages/torch/autograd/__init__.py", line 197, in backward
    Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
  File "/mnt/nvme/home/uwu/conda/nemo-113/lib/python3.8/site-packages/torch/autograd/function.py", line 267, in apply
    return user_fn(self, *args)
  File "/mnt/nvme/home/uwu/conda/nemo-113/lib/python3.8/site-packages/apex/transformer/tensor_parallel/layers.py", line 352, in backward
    grad_output = grad_output.view(
RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
```
This patch changes the view for a reshape which allows the layer after it to have a non-contiguous grad.